### PR TITLE
fixed typo preventing module from compiling

### DIFF
--- a/protoflo_python/__init__.py
+++ b/protoflo_python/__init__.py
@@ -35,7 +35,7 @@ def Int (metadata = None):
 
 def Float (metadata = None):
 	c = CastComponent(outPorts = [
-		('out': { "datatype": "number", "required": False })
+		('out', { "datatype": "number", "required": False })
 	])
 	
 	def process (data, groups, outPort):


### PR DESCRIPTION
There is a small typo in the python components module which prevents it from compiling. This also prevents example first.json from running.